### PR TITLE
Add a property to adjust localScale of SysFontText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,3 @@ unity/Assets/Plugins/Android/SysFont.jar.meta
 unity/Assets/Plugins/Android.meta
 unity/Assets/Plugins/SysFont.bundle/*
 unity/Assets/Plugins/SysFont.bundle.meta
-
-*.meta
-
-*.meta
-
-unity/Assets/SysFont/Editor/ISysFontTexturableEditor.cs.meta

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ unity/Assets/Plugins/Android/SysFont.jar.meta
 unity/Assets/Plugins/Android.meta
 unity/Assets/Plugins/SysFont.bundle/*
 unity/Assets/Plugins/SysFont.bundle.meta
+
+*.meta
+
+*.meta
+
+unity/Assets/SysFont/Editor/ISysFontTexturableEditor.cs.meta

--- a/unity/Assets/Plugins/SysFont/ISysFontTexturable.cs
+++ b/unity/Assets/Plugins/SysFont/ISysFontTexturable.cs
@@ -115,4 +115,10 @@ public interface ISysFontTexturable
   {
     get;
   }
+
+  float ScaleSize
+   {
+      get;
+      set;
+   }
 }

--- a/unity/Assets/Plugins/SysFont/SysFontText.cs
+++ b/unity/Assets/Plugins/SysFont/SysFontText.cs
@@ -406,8 +406,8 @@ public class SysFontText : MonoBehaviour, ISysFontTexturable
   public void UpdateScale()
   {
     Vector3 scale = _transform.localScale;
-      scale.x = (float)_texture.TextWidthPixels * _texture.ScaleSize;
-      scale.y = (float)_texture.TextHeightPixels * _texture.ScaleSize;
+    scale.x = (float)_texture.TextWidthPixels * _texture.ScaleSize;
+    scale.y = (float)_texture.TextHeightPixels * _texture.ScaleSize;
     _transform.localScale = scale;
   }
 

--- a/unity/Assets/Plugins/SysFont/SysFontText.cs
+++ b/unity/Assets/Plugins/SysFont/SysFontText.cs
@@ -202,6 +202,16 @@ public class SysFontText : MonoBehaviour, ISysFontTexturable
       return _texture.Texture;
     }
   }
+
+  public float ScaleSize
+   {
+      get{
+         return _texture.ScaleSize;
+      }
+      set{
+         _texture.ScaleSize = value;
+      }
+   }
   #endregion
 
   [SerializeField]
@@ -396,8 +406,8 @@ public class SysFontText : MonoBehaviour, ISysFontTexturable
   public void UpdateScale()
   {
     Vector3 scale = _transform.localScale;
-    scale.x = (float)_texture.TextWidthPixels;
-    scale.y = (float)_texture.TextHeightPixels;
+      scale.x = (float)_texture.TextWidthPixels * _texture.ScaleSize;
+      scale.y = (float)_texture.TextHeightPixels * _texture.ScaleSize;
     _transform.localScale = scale;
   }
 

--- a/unity/Assets/Plugins/SysFont/SysFontTexture.cs
+++ b/unity/Assets/Plugins/SysFont/SysFontTexture.cs
@@ -57,6 +57,9 @@ public class SysFontTexture : ISysFontTexturable
   [SerializeField]
   protected int _maxHeightPixels = 2048;
 
+  [SerializeField]
+  protected float _scaleSize = 0.0015f;
+
   protected string _lastText;
   public string Text
   {
@@ -242,6 +245,22 @@ public class SysFontTexture : ISysFontTexturable
     }
   }
 
+   protected float _lastScaleSize;
+   public float ScaleSize
+   {
+      get
+      {
+         return _scaleSize;
+      }
+      set
+      {
+         if(_scaleSize != value)
+         {
+            _scaleSize = value;
+         }
+      }
+   }
+
   protected int _widthPixels = 1;
   public int WidthPixels
   {
@@ -308,7 +327,8 @@ public class SysFontTexture : ISysFontTexturable
         (_alignment != _lastAlignment) ||
         (_isMultiLine != _lastIsMultiLine) ||
         (_maxWidthPixels != _lastMaxWidthPixels) ||
-        (_maxHeightPixels != _lastMaxHeightPixels);
+        (_maxHeightPixels != _lastMaxHeightPixels) ||
+        (_scaleSize != _lastScaleSize);
     }
   }
 
@@ -357,6 +377,7 @@ public class SysFontTexture : ISysFontTexturable
     _lastIsMultiLine = _isMultiLine;
     _lastMaxWidthPixels = _maxWidthPixels;
     _lastMaxHeightPixels = _maxHeightPixels;
+    _lastScaleSize = _scaleSize;
     return true;
   }
 

--- a/unity/Assets/Plugins/SysFont/SysFontTexture.cs
+++ b/unity/Assets/Plugins/SysFont/SysFontTexture.cs
@@ -58,7 +58,7 @@ public class SysFontTexture : ISysFontTexturable
   protected int _maxHeightPixels = 2048;
 
   [SerializeField]
-  protected float _scaleSize = 0.0015f;
+  protected float _scaleSize = 1f;
 
   protected string _lastText;
   public string Text

--- a/unity/Assets/SysFont/Editor/ISysFontTexturableEditor.cs
+++ b/unity/Assets/SysFont/Editor/ISysFontTexturableEditor.cs
@@ -167,9 +167,20 @@ public class ISysFontTexturableEditor : SysFontEditor
         RegisterUndo(target, "SysFont Max Height Pixels Change");
         texturable.MaxHeightPixels = maxHeightPixels;
       }
-
       LookLikeControls();
     }
     GUILayout.EndHorizontal();
+   //
+   //ScaleSize property
+   //
+   EditorGUIUtility.LookLikeControls(100f,110f);
+   float scaleSize = EditorGUILayout.FloatField("Camera Scale Size",
+         texturable.ScaleSize);
+   if(scaleSize != texturable.ScaleSize)
+   {
+      RegisterUndo(target,"SysFont Scale Size Change");
+      texturable.ScaleSize = scaleSize;
+   }
+   LookLikeControls();
   }
 }


### PR DESCRIPTION
As the used camera size it too expensive to change when add unity-sysfont to the project in a late time. Add this property to adjust the localScale of the SysFontText to fit the existing camera, so the user don't need to change the localScale every time after change the font size or text content.
